### PR TITLE
Force blaze-markup 0.6.2 to prevent ambigious trifecta error

### DIFF
--- a/check-page-fragmentation/check-page-fragmentation.cabal
+++ b/check-page-fragmentation/check-page-fragmentation.cabal
@@ -30,7 +30,8 @@ executable check-page-fragmentation
                      trifecta,
                      lens,
                      optparse-applicative,
-                     transformers
+                     transformers,
+                     blaze-markup <= 0.6.2
 
   ghc-options:       -O2
                      -threaded
@@ -53,6 +54,7 @@ test-suite           check-page-fragmentation-test
                      trifecta,
                      text,
                      lens,
-                     transformers
+                     transformers,
+                     blaze-markup <= 0.6.2
 
   ghc-options:       -fwarn-incomplete-patterns -threaded


### PR DESCRIPTION
Error:
```
src/Text/Trifecta/Highlight.hs:46:15:
    Ambiguous occurrence ‘Comment’
    It could refer to either ‘Text.Blaze.Internal.Comment’,
                             imported from ‘Text.Blaze.Internal’ at src/Text/Trifecta/Highlight.hs:35:1-26
                          or ‘Text.Parser.Token.Highlight.Comment’,
                             imported from ‘Text.Parser.Token.Highlight’ at src/Text/Trifecta/Highlight.hs:36:1-34
cabal: Error: some packages failed to install:
trifecta-1.5.1 failed during the building phase. The exception was:
ExitFailure 1
```

Fixed in ekmett/trifecta issue #40, but not yet on hackage. Once trifecta bumps to 1.5.2(?, or 1.6), should be self resolving, and this upper bound can be lifted